### PR TITLE
Added optional support for VCS-root

### DIFF
--- a/depbleed/main.go
+++ b/depbleed/main.go
@@ -17,7 +17,8 @@ type LintingError struct{}
 func (LintingError) Error() string { return "linting error" }
 
 var (
-	noFail bool
+	noFail     bool
+	useVCSRoot bool
 )
 
 var rootCmd = cobra.Command{
@@ -64,8 +65,14 @@ var rootCmd = cobra.Command{
 
 		failed := false
 
+		var options []depbleed.Option
+
+		if useVCSRoot {
+			options = append(options, depbleed.UseVCSRootOption(gopath))
+		}
+
 		for _, packagePath := range packagePaths {
-			packageInfo, err := depbleed.GetPackageInfo(packagePath)
+			packageInfo, err := depbleed.GetPackageInfo(packagePath, options...)
 
 			if err != nil {
 				return err
@@ -103,6 +110,7 @@ var rootCmd = cobra.Command{
 
 func init() {
 	rootCmd.Flags().BoolVar(&noFail, "no-fail", false, "Don't fail on errors")
+	rootCmd.Flags().BoolVarP(&useVCSRoot, "use-vcs-root", "g", false, "Use VCS root as package root")
 }
 
 func main() {

--- a/examples/exvcs/lib.go
+++ b/examples/exvcs/lib.go
@@ -1,0 +1,10 @@
+package exchan
+
+import "github.com/depbleed/go/examples/exchan"
+
+// MyType is an exposed type.
+type MyType struct {
+	// A is a public member of a VCS-local type. This is theoretical bleeding
+	// but in practice is fine.
+	A exchan.MyType
+}

--- a/examples/exvcs/vendor/a/lib.go
+++ b/examples/exvcs/vendor/a/lib.go
@@ -1,0 +1,3 @@
+package a
+
+type Type struct{}

--- a/go-depbleed/integration_test.go
+++ b/go-depbleed/integration_test.go
@@ -1,45 +1,60 @@
 package depbleed
 
 import (
+	"os"
 	"testing"
 )
 
 func TestExamples(t *testing.T) {
 	testCases := []struct {
-		PackagePath string
-		LeaksCount  int
+		PackagePath      string
+		LeaksCount       int
+		UseVCSLeaksCount int
 	}{
 		{
-			PackagePath: "github.com/depbleed/go/examples/exinterface",
-			LeaksCount:  2,
+			PackagePath:      "github.com/depbleed/go/examples/exinterface",
+			LeaksCount:       2,
+			UseVCSLeaksCount: 2,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/exstruct",
-			LeaksCount:  1,
+			PackagePath:      "github.com/depbleed/go/examples/exstruct",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 1,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/exmap",
-			LeaksCount:  2,
+			PackagePath:      "github.com/depbleed/go/examples/exmap",
+			LeaksCount:       2,
+			UseVCSLeaksCount: 2,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/exslice",
-			LeaksCount:  1,
+			PackagePath:      "github.com/depbleed/go/examples/exslice",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 1,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/exarray",
-			LeaksCount:  1,
+			PackagePath:      "github.com/depbleed/go/examples/exarray",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 1,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/expointer",
-			LeaksCount:  1,
+			PackagePath:      "github.com/depbleed/go/examples/expointer",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 1,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/exchan",
-			LeaksCount:  1,
+			PackagePath:      "github.com/depbleed/go/examples/exchan",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 1,
 		},
 		{
-			PackagePath: "github.com/depbleed/go/examples/excomplete",
-			LeaksCount:  13,
+			PackagePath:      "github.com/depbleed/go/examples/exvcs",
+			LeaksCount:       1,
+			UseVCSLeaksCount: 0,
+		},
+		{
+			PackagePath:      "github.com/depbleed/go/examples/excomplete",
+			LeaksCount:       13,
+			UseVCSLeaksCount: 12,
 		},
 		{
 			PackagePath: "github.com/depbleed/go/examples/exmain",
@@ -58,6 +73,20 @@ func TestExamples(t *testing.T) {
 
 			if len(leaks) != testCase.LeaksCount {
 				t.Errorf("expected %d leak(s) got %d", testCase.LeaksCount, len(leaks))
+			}
+		})
+		t.Run(testCase.PackagePath+" use-vcs", func(t *testing.T) {
+			gopath := os.Getenv("GOPATH")
+			packageInfo, err := GetPackageInfo(testCase.PackagePath, UseVCSRootOption(gopath))
+
+			if err != nil {
+				t.Fatalf("expected no error but got: %s", err)
+			}
+
+			leaks := packageInfo.Leaks()
+
+			if len(leaks) != testCase.UseVCSLeaksCount {
+				t.Errorf("expected %d leak(s) got %d", testCase.UseVCSLeaksCount, len(leaks))
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds support for an optional `--use-vcs-root` option that always considers the root of VCS as the topmost root for package resolution.

For now, only Git is supported as a VCS. The behavior is opt-in.